### PR TITLE
Marks 'run' commands that were failing as multiline strings

### DIFF
--- a/.github/workflows/test_data.yml
+++ b/.github/workflows/test_data.yml
@@ -23,10 +23,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install packages
-        run:
+        run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
 
       - name: Run data tests
-        run:
+        run: |
           pytest test/test_data.py -m "(longruns or not longruns) and not highmemory" -s -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run:
+        run: |
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions
 


### PR DESCRIPTION
This PR simply adds some missing `|` indicators to multiline `run` commands in workflows. Without the mark, the commands in the `run` block are interpreted as a single string, leading to invocations like `python -m pip install --upgrade pip pip install tox tox-gh-actions` that caused workflow run failures.